### PR TITLE
Adding Terragrunt HCL formatting command 

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -149,8 +149,9 @@ function installTerragrunt {
 
 function main {
   # Source the other files to gain access to their functions
-  scriptDir=$(dirname ${0})
+  scriptDir=$(dirname ${0})  
   source ${scriptDir}/terragrunt_fmt.sh
+  source ${scriptDir}/terragrunt_hclfmt.sh  
   source ${scriptDir}/terragrunt_init.sh
   source ${scriptDir}/terragrunt_validate.sh
   source ${scriptDir}/terragrunt_plan.sh
@@ -166,6 +167,10 @@ function main {
   cd ${GITHUB_WORKSPACE}/${tfWorkingDir}
 
   case "${tfSubcommand}" in
+    hclfmt)
+      installTerragrunt
+      terragruntHCLFmt ${*}
+      ;;
     fmt)
       installTerragrunt
       terragruntFmt ${*}

--- a/src/terragrunt_hclfmt.sh
+++ b/src/terragrunt_hclfmt.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+function terragruntHCLFmt {
+  # Gather the output of `terragrunt hclfmt`.
+  echo "fmt: info: checking if Terragrunt files in ${tfWorkingDir} are correctly formatted"
+  fmtOutput=$(${tfBinary} hclfmt ${*} 2>&1)
+  fmtExitCode=${?}
+
+  # Exit code of 0 indicates success. Print the output and exit.
+  if [ ${fmtExitCode} -eq 0 ]; then
+    echo "fmt: info: Terragrunt files in ${tfWorkingDir} are correctly formatted"
+    echo "${fmtOutput}"
+    echo
+    exit ${fmtExitCode}
+  fi
+
+  # Exit code of 2 indicates a parse error. Print the output and exit.
+  if [ ${fmtExitCode} -eq 2 ]; then
+    echo "fmt: error: failed to parse Terragrunt files"
+    echo "${fmtOutput}"
+    echo
+    exit ${fmtExitCode}
+  fi
+
+  # Exit code of !0 and !2 indicates failure.
+  echo "fmt: error: Terragrunt files in ${tfWorkingDir} are incorrectly formatted"
+  echo "${fmtOutput}"
+  echo
+  echo "fmt: error: the following files in ${tfWorkingDir} are incorrectly formatted"
+  fmtFileList=$(${tfBinary} fmt -check=true -write=false -list ${fmtRecursive})
+  echo "${fmtFileList}"
+  echo
+
+  # Comment on the pull request if necessary.
+  if [ "$GITHUB_EVENT_NAME" == "pull_request" ] && [ "${tfComment}" == "1" ]; then
+    fmtComment=""
+    for file in ${fmtFileList}; do
+      fmtFileDiff=$(${tfBinary} fmt -check=true -write=false -diff "${file}" | sed -n '/@@.*/,//{/@@.*/d;p}')
+      fmtComment="${fmtComment}
+<details><summary><code>${tfWorkingDir}/${file}</code></summary>
+\`\`\`diff
+${fmtFileDiff}
+\`\`\`
+</details>"
+
+    done
+
+    fmtCommentWrapper="#### \`${tfBinary} fmt\` Failed
+${fmtComment}
+*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
+
+    fmtCommentWrapper=$(stripColors "${fmtCommentWrapper}")
+    echo "fmt: info: creating JSON"
+    fmtPayload=$(echo "${fmtCommentWrapper}" | jq -R --slurp '{body: .}')
+    fmtCommentsURL=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)
+    echo "fmt: info: commenting on the pull request"
+    echo "${fmtPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${fmtCommentsURL}" > /dev/null
+  fi
+
+  # Write changes to branch
+  echo "::set-output name=tf_actions_fmt_written::false"
+  if [ "${tfFmtWrite}" == "1" ]; then
+    echo "fmt: info: Terraform files in ${tfWorkingDir} will be formatted"
+    terraform fmt -write=true ${fmtRecursive} "${*}"
+    fmtExitCode=${?}
+    echo "::set-output name=tf_actions_fmt_written::true"
+  fi
+
+  exit ${fmtExitCode}
+}


### PR DESCRIPTION
Currently `fmt` only formats Terraform files but not Terragrunt files. 
This adds a command that wraps `terragrunt hclfmt` allows user to format Terragrunt files with `*.hcl` extension. 

Note this will do nothing if `tf_binary == terraform` as Terraform cannot be used to format Terragrunt files