### PR TITLE
Add support for `terragrunt show`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,47 +1,49 @@
-name: 'Terragrunt GitHub Actions'
-description: 'Runs Terragrunt commands via GitHub Actions.'
-author:  'HashiCorp, Inc. Terraform Team <terraform@hashicorp.com>'
+name: "Terragrunt GitHub Actions"
+description: "Runs Terragrunt commands via GitHub Actions."
+author: "HashiCorp, Inc. Terraform Team <terraform@hashicorp.com>"
 branding:
-  icon: 'cloud'
-  color: 'purple'
+  icon: "cloud"
+  color: "purple"
 inputs:
   tf_actions_subcommand:
-    description: 'Terraform or Terragrunt subcommand to execute.'
+    description: "Terraform or Terragrunt subcommand to execute."
     required: true
   tf_actions_binary:
-    description: 'Binary to use. Terraform or Terragrunt'
-    default: 'terragrunt'
+    description: "Binary to use. Terraform or Terragrunt"
+    default: "terragrunt"
   tf_actions_version:
-    description: 'Terraform version to install.'
+    description: "Terraform version to install."
     required: true
-    default: 'latest'
+    default: "latest"
   tg_actions_version:
-    description: 'Terragrunt version to install.'
+    description: "Terragrunt version to install."
     required: true
-    default: 'latest'
+    default: "latest"
   tf_actions_cli_credentials_hostname:
-    description: 'Hostname for the CLI credentials file.'
-    default: 'app.terraform.io'
+    description: "Hostname for the CLI credentials file."
+    default: "app.terraform.io"
   tf_actions_cli_credentials_token:
-    description: 'Token for the CLI credentials file.'
+    description: "Token for the CLI credentials file."
   tf_actions_comment:
-    description: 'Whether or not to comment on pull requests.'
+    description: "Whether or not to comment on pull requests."
     default: true
   tf_actions_working_dir:
-    description: 'Terragrunt working directory.'
-    default: '.'
+    description: "Terragrunt working directory."
+    default: "."
   tf_actions_fmt_write:
-    description: 'Write Terragrunt fmt changes to source files.'
+    description: "Write Terragrunt fmt changes to source files."
     default: false
 outputs:
   tf_actions_output:
-    description: 'The Terragrunt outputs in JSON format.'
+    description: "The Terragrunt outputs in JSON format."
   tf_actions_plan_has_changes:
-    description: 'Whether or not the Terragrunt plan contained changes.'
+    description: "Whether or not the Terragrunt plan contained changes."
   tf_actions_plan_output:
-    description: 'The Terragrunt plan output.'
+    description: "The Terragrunt plan output."
   tf_actions_fmt_written:
-    description: 'Whether or not the Terragrunt formatting was written to source files.'
+    description: "Whether or not the Terragrunt formatting was written to source files."
+  tf_actions_show_output:
+    description: "The Terragrunt show output"
 runs:
-  using: 'docker'
-  image: './Dockerfile'
+  using: "docker"
+  image: "./Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
   tf_actions_fmt_write:
     description: "Write Terragrunt fmt changes to source files."
     default: false
+  tf_actions_show_file:
+    description: "File name to write the output of show subcommand"
+    default: "plan.json"
 outputs:
   tf_actions_output:
     description: "The Terragrunt outputs in JSON format."

--- a/src/main.sh
+++ b/src/main.sh
@@ -69,7 +69,7 @@ function parseInputs() {
     tfFmtWrite=1
   fi
 
-  tfShowFile="${INPUT_TF_ACTIONS_SHOW_FILE}:-plan.json"
+  tfShowFile="${INPUT_TF_ACTIONS_SHOW_FILE:-plan.json}"
 
   tfWorkspace="default"
   if [ -n "${TF_WORKSPACE}" ]; then

--- a/src/main.sh
+++ b/src/main.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 
-function stripColors {
+function stripColors() {
   echo "${1}" | sed 's/\x1b\[[0-9;]*m//g'
 }
 
-function hasPrefix {
+function hasPrefix() {
   case ${2} in
-    "${1}"*)
-      true
-      ;;
-    *)
-      false
-      ;;
+  "${1}"*)
+    true
+    ;;
+  *)
+    false
+    ;;
   esac
 }
 
-function parseInputs {
+function parseInputs() {
   # Required inputs
   if [ "${INPUT_TF_ACTIONS_VERSION}" != "" ]; then
     tfVersion=${INPUT_TF_ACTIONS_VERSION}
@@ -75,9 +75,9 @@ function parseInputs {
   fi
 }
 
-function configureCLICredentials {
+function configureCLICredentials() {
   if [[ ! -f "${HOME}/.terraformrc" ]] && [[ "${tfCLICredentialsToken}" != "" ]]; then
-    cat > ${HOME}/.terraformrc << EOF
+    cat >${HOME}/.terraformrc <<EOF
 credentials "${tfCLICredentialsHostname}" {
   token = "${tfCLICredentialsToken}"
 }
@@ -85,7 +85,7 @@ EOF
   fi
 }
 
-function installTerraform {
+function installTerraform() {
   if [[ "${tfVersion}" == "latest" ]]; then
     echo "Checking the latest version of Terraform"
     tfVersion=$(curl -sL https://releases.hashicorp.com/terraform/index.json | jq -r '.versions[].version' | grep -v '[-].*' | sort -rV | head -n 1)
@@ -107,7 +107,7 @@ function installTerraform {
   echo "Successfully downloaded Terraform v${tfVersion}"
 
   echo "Unzipping Terraform v${tfVersion}"
-  unzip -d /usr/local/bin /tmp/terraform_${tfVersion} &> /dev/null
+  unzip -d /usr/local/bin /tmp/terraform_${tfVersion} &>/dev/null
   if [ "${?}" -ne 0 ]; then
     echo "Failed to unzip Terraform v${tfVersion}"
     exit 1
@@ -115,7 +115,7 @@ function installTerraform {
   echo "Successfully unzipped Terraform v${tfVersion}"
 }
 
-function installTerragrunt {
+function installTerragrunt() {
   if [[ "${tgVersion}" == "latest" ]]; then
     echo "Checking the latest version of Terragrunt"
     latestURL=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/gruntwork-io/terragrunt/releases/latest)
@@ -139,7 +139,7 @@ function installTerragrunt {
 
   echo "Moving Terragrunt ${tgVersion} to PATH"
   chmod +x /tmp/terragrunt
-  mv /tmp/terragrunt /usr/local/bin/terragrunt 
+  mv /tmp/terragrunt /usr/local/bin/terragrunt
   if [ "${?}" -ne 0 ]; then
     echo "Failed to move Terragrunt ${tgVersion}"
     exit 1
@@ -147,7 +147,7 @@ function installTerragrunt {
   echo "Successfully moved Terragrunt ${tgVersion}"
 }
 
-function main {
+function main() {
   # Source the other files to gain access to their functions
   scriptDir=$(dirname ${0})
   source ${scriptDir}/terragrunt_fmt.sh
@@ -159,6 +159,7 @@ function main {
   source ${scriptDir}/terragrunt_import.sh
   source ${scriptDir}/terragrunt_taint.sh
   source ${scriptDir}/terragrunt_destroy.sh
+  source ${scriptDir}/terragrunt_show.sh
 
   parseInputs
   configureCLICredentials
@@ -166,46 +167,50 @@ function main {
   cd ${GITHUB_WORKSPACE}/${tfWorkingDir}
 
   case "${tfSubcommand}" in
-    fmt)
-      installTerragrunt
-      terragruntFmt ${*}
-      ;;
-    init)
-      installTerragrunt
-      terragruntInit ${*}
-      ;;
-    validate)
-      installTerragrunt
-      terragruntValidate ${*}
-      ;;
-    plan)
-      installTerragrunt
-      terragruntPlan ${*}
-      ;;
-    apply)
-      installTerragrunt
-      terragruntApply ${*}
-      ;;
-    output)
-      installTerragrunt
-      terragruntOutput ${*}
-      ;;
-    import)
-      installTerragrunt
-      terragruntImport ${*}
-      ;;
-    taint)
-      installTerragrunt
-      terragruntTaint ${*}
-      ;;
-    destroy)
-      installTerragrunt
-      terragruntDestroy ${*}
-      ;;
-    *)
-      echo "Error: Must provide a valid value for terragrunt_subcommand"
-      exit 1
-      ;;
+  fmt)
+    installTerragrunt
+    terragruntFmt ${*}
+    ;;
+  init)
+    installTerragrunt
+    terragruntInit ${*}
+    ;;
+  validate)
+    installTerragrunt
+    terragruntValidate ${*}
+    ;;
+  plan)
+    installTerragrunt
+    terragruntPlan ${*}
+    ;;
+  show)
+    installTerragrunt
+    terragruntShow ${*}
+    ;;
+  apply)
+    installTerragrunt
+    terragruntApply ${*}
+    ;;
+  output)
+    installTerragrunt
+    terragruntOutput ${*}
+    ;;
+  import)
+    installTerragrunt
+    terragruntImport ${*}
+    ;;
+  taint)
+    installTerragrunt
+    terragruntTaint ${*}
+    ;;
+  destroy)
+    installTerragrunt
+    terragruntDestroy ${*}
+    ;;
+  *)
+    echo "Error: Must provide a valid value for terragrunt_subcommand"
+    exit 1
+    ;;
   esac
 }
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -69,6 +69,8 @@ function parseInputs() {
     tfFmtWrite=1
   fi
 
+  tfShowFile="${INPUT_TF_ACTIONS_SHOW_FILE}:-plan.json"
+
   tfWorkspace="default"
   if [ -n "${TF_WORKSPACE}" ]; then
     tfWorkspace="${TF_WORKSPACE}"

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -3,8 +3,8 @@
 function terragruntShow() {
   # Gather the output of `terragrunt plan`.
   echo "show: info: showing Terragrunt configuration in ${tfWorkingDir}"
-  # showOutput=$(${tfBinary} show -no-color ${*} 2>&1)
-  showOutput=$(${tfBinary} show -no-color -json plan.out >plan.json)
+  showOutput=$(${tfBinary} show -no-color ${*} 2>&1)
+  # showOutput=$(${tfBinary} show -no-color -json plan.out >plan.json)
   showExitCode=${?}
   showCommentStatus="Failed"
 

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -3,8 +3,7 @@
 function terragruntShow() {
   # Gather the output of `terragrunt plan`.
   echo "show: info: showing Terragrunt configuration in ${tfWorkingDir}"
-  # showOutput=$(${tfBinary} show -no-color ${*} 2>&1)
-  showOutput=$(${tfBinary} show -no-color ${*})
+  showOutput=$(${tfBinary} show -no-color ${*} 2>&1)
   showExitCode=${?}
   showCommentStatus="Failed"
 
@@ -12,6 +11,7 @@ function terragruntShow() {
   if [ ${showExitCode} -eq 0 ]; then
     echo "show: info: successfully showed Terragrunt configuration in ${tfWorkingDir}"
     echo "${showOutput}"
+    echo ${showOutput} >plan.json
     echo
     exit ${showExitCode}
   fi

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -3,7 +3,8 @@
 function terragruntShow() {
   # Gather the output of `terragrunt plan`.
   echo "show: info: showing Terragrunt configuration in ${tfWorkingDir}"
-  showOutput=$(${tfBinary} show -no-color ${*} 2>&1)
+  # showOutput=$(${tfBinary} show -no-color ${*} 2>&1)
+  showOutput=$(${tfBinary} show -no-color -json plan.out >plan.json)
   showExitCode=${?}
   showCommentStatus="Failed"
 

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -3,8 +3,7 @@
 function terragruntShow() {
   # Gather the output of `terragrunt plan`.
   echo "show: info: showing Terragrunt configuration in ${tfWorkingDir}"
-  showOutput=$(${tfBinary} show -no-color ${*})
-  # showOutput=$(${tfBinary} show -no-color -json plan.out >plan.json)
+  showOutput=$(${tfBinary} show -no-color ${*} 2>&1)
   showExitCode=${?}
   showCommentStatus="Failed"
 

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -3,7 +3,7 @@
 function terragruntShow() {
   # Gather the output of `terragrunt plan`.
   echo "show: info: showing Terragrunt configuration in ${tfWorkingDir}"
-  showOutput=$(${tfBinary} show -detailed-exitcode -no-color ${*} 2>&1)
+  showOutput=$(${tfBinary} show -no-color ${*} 2>&1)
   showExitCode=${?}
   showCommentStatus="Failed"
 

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -11,7 +11,7 @@ function terragruntShow() {
   if [ ${showExitCode} -eq 0 ]; then
     echo "show: info: successfully showed Terragrunt configuration in ${tfWorkingDir}"
     echo "${showOutput}"
-    echo ${showOutput} >plan.json
+    echo ${showOutput} >${tfShowFile}
     echo
     exit ${showExitCode}
   fi

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -3,7 +3,8 @@
 function terragruntShow() {
   # Gather the output of `terragrunt plan`.
   echo "show: info: showing Terragrunt configuration in ${tfWorkingDir}"
-  showOutput=$(${tfBinary} show -no-color ${*} 2>&1)
+  # showOutput=$(${tfBinary} show -no-color ${*} 2>&1)
+  showOutput=$(${tfBinary} show -no-color ${*})
   showExitCode=${?}
   showCommentStatus="Failed"
 

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -10,7 +10,8 @@ function terragruntShow() {
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${showExitCode} -eq 0 ]; then
     echo "show: info: successfully showed Terragrunt configuration in ${tfWorkingDir}"
-    echo "${showOutput}"
+    # echo "${showOutput}"
+    echo "show: info: saving data to ${tfShowFile}"
     echo ${showOutput} >${tfShowFile}
     echo
     exit ${showExitCode}

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -3,7 +3,7 @@
 function terragruntShow() {
   # Gather the output of `terragrunt plan`.
   echo "show: info: showing Terragrunt configuration in ${tfWorkingDir}"
-  showOutput=$(${tfBinary} show -no-color ${*} 2>&1)
+  showOutput=$(${tfBinary} show -no-color ${*})
   showExitCode=${?}
   showCommentStatus="Failed"
 

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+function terragruntShow() {
+  # Gather the output of `terragrunt plan`.
+  echo "show: info: showing Terragrunt configuration in ${tfWorkingDir}"
+  showOutput=$(${tfBinary} show -detailed-exitcode -no-color ${*} 2>&1)
+  showExitCode=${?}
+  showCommentStatus="Failed"
+
+  # Exit code of 0 indicates success with no changes. Print the output and exit.
+  if [ ${showExitCode} -eq 0 ]; then
+    echo "show: info: successfully showed Terragrunt configuration in ${tfWorkingDir}"
+    echo "${showOutput}"
+    echo
+    exit ${showExitCode}
+  fi
+
+  # Exit code of !0 indicates failure.
+  if [ ${showExitCode} -ne 0 ]; then
+    echo "show: error: failed to show Terragrunt configuration in ${tfWorkingDir}"
+    echo "${showOutput}"
+    echo
+  fi
+
+  # Comment on the pull request if necessary.
+  if [ "$GITHUB_EVENT_NAME" == "pull_request" ] && [ "${tfComment}" == "1" ] && [ "${showCommentStatus}" == "Failed" ]; then
+    showCommentWrapper="#### \`${tfBinary} show\` ${showCommentStatus}
+<details><summary>Show Output</summary>
+
+\`\`\`
+${showOutput}
+\`\`\`
+
+</details>
+
+*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
+
+    showCommentWrapper=$(stripColors "${showCommentWrapper}")
+    echo "show: info: creating JSON"
+    showPayload=$(echo "${showCommentWrapper}" | jq -R --slurp '{body: .}')
+    showCommentsURL=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)
+    echo "show: info: commenting on the pull request"
+    echo "${showPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${showCommentsURL}" >/dev/null
+  fi
+
+  # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
+  showOutput="${showOutput//'%'/'%25'}"
+  showOutput="${showOutput//$'\n'/'%0A'}"
+  showOutput="${showOutput//$'\r'/'%0D'}"
+
+  echo "::set-output name=tf_actions_show_output::${showOutput}"
+  exit ${showExitCode}
+}

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -3,7 +3,7 @@
 function terragruntShow() {
   # Gather the output of `terragrunt plan`.
   echo "show: info: showing Terragrunt configuration in ${tfWorkingDir}"
-  showOutput=$(${tfBinary} show -no-color ${*} 2>&1)
+  showOutput=$(${tfBinary} show -no-color ${*})
   # showOutput=$(${tfBinary} show -no-color -json plan.out >plan.json)
   showExitCode=${?}
   showCommentStatus="Failed"


### PR DESCRIPTION
Not sure if it's a bug or not but https://github.com/the-commons-project/terragrunt-github-actions/blob/259fc9e56d89b4331cf23f6d3c4a1895cc754d2a/src/main.sh#L205-L208 means subcommands only supported by `terraform` (i.e. `show`) are not passed "down" to `terraform`.

I'm not sure about the best way to fix this. This PR adds support specifically for the `terraform show` (sub)command.

Perhaps a more general fix would be to just handle whatever `terraform` returns. But I really don't know if that's a good idea or not.

Anyway, here's a PR adding some functionality. HTH.