### PR TITLE
fix silent error when Terragrunt or Terraform executable is unable to be downloaded

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -99,8 +99,8 @@ function installTerraform {
   url="https://releases.hashicorp.com/terraform/${tfVersion}/terraform_${tfVersion}_linux_amd64.zip"
 
   echo "Downloading Terraform v${tfVersion}"
-  curl -s -S -L -o /tmp/terraform_${tfVersion} ${url}
-  if [ "${?}" -ne 0 ]; then
+  status_code=$(curl -s -S -L -o /tmp/terraform_${tfVersion} --write-out "%{http_code}" ${url})
+  if [ "${?}" -ne 0 ] || [ "${status_code}" -ne "200" ]; then
     echo "Failed to download Terraform v${tfVersion}"
     exit 1
   fi
@@ -130,8 +130,8 @@ function installTerragrunt {
   url="https://github.com/gruntwork-io/terragrunt/releases/download/${tgVersion}/terragrunt_linux_amd64"
 
   echo "Downloading Terragrunt ${tgVersion}"
-  curl -s -S -L -o /tmp/terragrunt ${url}
-  if [ "${?}" -ne 0 ]; then
+  status_code=$(curl -s -S -L -o /tmp/terragrunt --write-out "%{http_code}" ${url})
+  if [ "${?}" -ne 0 ] || [ "${status_code}" -ne "200" ]; then
     echo "Failed to download Terragrunt ${tgVersion}"
     exit 1
   fi


### PR DESCRIPTION
If the Terragrunt version is invalid (e.g. missing a `v` in front), we still see a `Successfully downloaded Terragrunt` message. This PR fixes it so if the URL returns a `404` the Action fails with `Failed to download Terragrunt`.

Similar issue with Terraform download, except it *cannot* have a `v` in front. This is a point of confusion and might be good to put in an example since the examples just use `latest`.